### PR TITLE
Fix unwritten new file to flush

### DIFF
--- a/src/nuummite.cr
+++ b/src/nuummite.cr
@@ -52,6 +52,7 @@ class Nuummite
     file = File.new(path, "a")
     if new_file
       file.write_byte(VERSION.to_u8)
+      file.flush
     end
     {file, kv}
   end


### PR DESCRIPTION
This fixes the error where a database file is created when a new one is created, but nothing is written to it due to the buffering nature of writes. Application crashes on restart due to `version = file.read_byte.not_nil!`, as file is empty.