### PR TITLE
Replace Dir.rmdir

### DIFF
--- a/spec/benchmark.cr
+++ b/spec/benchmark.cr
@@ -54,5 +54,5 @@ def clean(dir_name = "tmpdb")
     path = "#{dir_name}#{File::SEPARATOR}#{filename}"
     File.delete(path) if File.file?(path)
   end
-  Dir.rmdir(dir_name)
+  Dir.delete(dir_name)
 end

--- a/spec/nuummite_spec.cr
+++ b/spec/nuummite_spec.cr
@@ -138,5 +138,5 @@ def clean(dir_name = "tmpdb")
     path = "#{dir_name}#{File::SEPARATOR}#{filename}"
     File.delete(path) if File.file?(path)
   end
-  Dir.rmdir(dir_name)
+  Dir.delete(dir_name)
 end


### PR DESCRIPTION
Dir.rmdir was replaced with Dir.delete. Dir.rmdir is not available anymore since Crystal 1.0.0.

I had nothing to do, found a compile error and felt the urge to fix it... ¯\_(ツ)_/¯